### PR TITLE
Implement a simple MPIService

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,7 +1,6 @@
 <architecture name="slc6_amd64">
   <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
 </architecture>
-<use   name="openmpi"/>
 <bin   name="cmsRunGlibC" file="cmsRun.cpp">
   <use   name="roothistmatrix"/>
   <use   name="tbb"/>

--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -37,8 +37,6 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 #include <memory>
 #include <string>
 #include <vector>
-#include <mpi.h>
-#include <cassert>
 
 //Command line parameters
 static char const* const kParameterSetOpt = "parameter-set";
@@ -125,10 +123,6 @@ namespace {
 }
 
 int main(int argc, char* argv[]) {
-
-  int provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-  assert(provided == MPI_THREAD_MULTIPLE);
 
   edm::TimingServiceBase::jobStarted();
   
@@ -400,6 +394,5 @@ int main(int argc, char* argv[]) {
   }
   // Disable Root Error Handler.
   SetErrorHandler(DefaultErrorHandler);
-  MPI_Finalize();
   return returnCode;
 }

--- a/HeterogeneousCore/MPICore/test/cpuNode.py
+++ b/HeterogeneousCore/MPICore/test/cpuNode.py
@@ -13,6 +13,8 @@ process = cms.Process("TEST")
 
 process.source = cms.Source("EmptySource")
 
+process.MPIService = cms.Service("MPIService")
+
 process.produce = cms.EDProducer("ArraysProducer",
     vectorLength = cms.int32(int(options.vlen))
 )

--- a/HeterogeneousCore/MPICore/test/gpuNode.py
+++ b/HeterogeneousCore/MPICore/test/gpuNode.py
@@ -18,6 +18,8 @@ process = cms.Process("TEST")
 
 process.source = cms.Source("EmptySource")
 
+process.MPIService = cms.Service("MPIService")
+
 process.fetch = cms.EDProducer("FetchProducer")
 
 process.work = cms.EDProducer("WorkProducer",

--- a/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="openmpi"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<flags EDM_PLUGIN="1"/>

--- a/HeterogeneousCore/MPIServices/plugins/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/plugins/MPIService.cc
@@ -1,0 +1,39 @@
+// -*- C++ -*-
+
+#include <cassert>
+
+#include <mpi.h>
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+class MPIService {
+public:
+  MPIService(edm::ParameterSet const& config, edm::ActivityRegistry & registry);
+  ~MPIService();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+};
+
+MPIService::MPIService(edm::ParameterSet const & config, edm::ActivityRegistry & registry)
+{
+  int provided;
+  MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+  assert(provided == MPI_THREAD_MULTIPLE);
+}
+
+MPIService::~MPIService() {
+  MPI_Finalize();
+}
+
+void
+MPIService::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("MPIService", desc);
+  descriptions.setComment(R"(This Service provides a common interface to MPI configuration for the CMSSW job.)");
+}
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+DEFINE_FWK_SERVICE(MPIService);


### PR DESCRIPTION
Move the MPI initialisation from `main` to a dedicated `MPIService`, and update the tests to load it.